### PR TITLE
Compatibility with more "tty's"

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func getTerminalSizeFallback() (int, int) {
 
 	if columns*rows == 0 {
 		// Well. This is the default for many terminals.
-		return 80, 25
+		return 80, 24
 	}
 
 	return columns, rows


### PR DESCRIPTION
This PR should fix compatiblity for some cornercases.

- When running in `docker run` with `-t -i`.
- When running in `docker run` with `-t`.
- When running in `docker run` with `-i`.
- When running non-interactive without a tty in `docker run`.
- When running in a `ctop`-shell.
- When running as a `ssh` `exec` command.